### PR TITLE
Release 0.0.1a2

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -32,5 +32,5 @@ jobs:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        python setup.py sdist
+        python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-thonny>=3,<4
+thonny>=3.0.0,<4
 crosshair-tool>=0.0.11,<2
 
 # Icontract is, strictly speaking, not required for this plug-in.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setuptools.setup(
     name="thonny-crosshair",
-    version="0.0.1a1",
+    version="0.0.1a2",
     author="Marko Ristin",
     author_email="marko@ristin.ch",
     description="Automatically verify Python code using CrossHair in Thonny.",


### PR DESCRIPTION
This alpha release includes the wheel package in the distribution. We
are having problems with the field `requires_dist` not being set in the
package meta-data, which Thonny uses to determine the required Thonny
version.