### PR TITLE
Use `sys.executable` in shell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setuptools.setup(
     name="thonny-crosshair",
-    version="0.0.1a2",
+    version="0.0.1a3",
     author="Marko Ristin",
     author_email="marko@ristin.ch",
     description="Automatically verify Python code using CrossHair in Thonny.",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 """Test the plugin functions both public and private."""
 import os
+import sys
 import unittest
 import unittest.mock
 
@@ -82,7 +83,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line='! python -m crosshair check "some file.py"\n',
+                cmd_line=f'! {sys.executable} -m crosshair check "some file.py"\n',
                 tags=unittest.mock.ANY
             )
 
@@ -107,7 +108,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line='! python -m crosshair check "some file.py:1984"\n',
+                cmd_line=f'! {sys.executable} -m crosshair check "some file.py:1984"\n',
                 tags=unittest.mock.ANY
             )
 
@@ -131,7 +132,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line='! python -m crosshair watch "some file.py"\n',
+                cmd_line=f'! {sys.executable} -m crosshair watch "some file.py"\n',
                 tags=unittest.mock.ANY
             )
 

--- a/thonnycontrib/thonny_crosshair/__init__.py
+++ b/thonnycontrib/thonny_crosshair/__init__.py
@@ -1,6 +1,7 @@
 """Automatically test Python code using CrossHair in Thonny."""
 import enum
 import subprocess
+import sys
 import tkinter.messagebox
 
 import thonny
@@ -65,19 +66,17 @@ def _execute(workbench: thonny.workbench.Workbench, command: _Command) -> None:
     editor.save_file()
 
     if command == _Command.CHECK:
-        cmd = ["!", "python", "-m", "crosshair", "check", filename]
+        cmd = ["!", sys.executable, "-m", "crosshair", "check", filename]
     elif command == _Command.CHECK_AT:
         selection = editor.get_code_view().get_selected_range()
+        # fmt: off
         cmd = [
-            "!",
-            "python",
-            "-m",
-            "crosshair",
-            "check",
+            "!", sys.executable, "-m", "crosshair", "check",
             f"{filename}:{selection.lineno}",
         ]
+        # fmt: on
     elif command == _Command.WATCH:
-        cmd = ["!", "python", "-m", "crosshair", "watch", filename]
+        cmd = ["!", sys.executable, "-m", "crosshair", "watch", filename]
     else:
         raise NotImplementedError(f"Unhandled command: {command}")
 


### PR DESCRIPTION
We need to use `sys.executable` instead of simply `python` in order to
run the crosshair module with the python interpreter belonging to
Thonny, not the system one.