### PR TITLE
Fix crosshair watch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 thonny>=3.0.0,<4
-crosshair-tool>=0.0.11,<2
+crosshair-tool>=0.0.13,<2
 
 # Icontract is, strictly speaking, not required for this plug-in.
 # However, we include it in the package to make the life easier for

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,7 +83,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line=f'! {sys.executable} -m crosshair check "some file.py"\n',
+                cmd_line=f'! crosshair check "some file.py"\n',
                 tags=unittest.mock.ANY
             )
 
@@ -108,7 +108,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line=f'! {sys.executable} -m crosshair check "some file.py:1984"\n',
+                cmd_line=f'! crosshair check "some file.py:1984"\n',
                 tags=unittest.mock.ANY
             )
 
@@ -132,7 +132,7 @@ class TestCheck(unittest.TestCase):
             editor.save_file.assert_called_once()
 
             shell.text.submit_command.assert_called_with(
-                cmd_line=f'! {sys.executable} -m crosshair watch "some file.py"\n',
+                cmd_line=f'! crosshair watch "some file.py"\n',
                 tags=unittest.mock.ANY
             )
 

--- a/thonnycontrib/thonny_crosshair/__init__.py
+++ b/thonnycontrib/thonny_crosshair/__init__.py
@@ -1,7 +1,6 @@
 """Automatically test Python code using CrossHair in Thonny."""
 import enum
 import subprocess
-import sys
 import tkinter.messagebox
 
 import thonny
@@ -66,17 +65,17 @@ def _execute(workbench: thonny.workbench.Workbench, command: _Command) -> None:
     editor.save_file()
 
     if command == _Command.CHECK:
-        cmd = ["!", sys.executable, "-m", "crosshair", "check", filename]
+        cmd = ["!", "crosshair", "check", filename]
     elif command == _Command.CHECK_AT:
         selection = editor.get_code_view().get_selected_range()
         # fmt: off
         cmd = [
-            "!", sys.executable, "-m", "crosshair", "check",
+            "!", "crosshair", "check",
             f"{filename}:{selection.lineno}",
         ]
         # fmt: on
     elif command == _Command.WATCH:
-        cmd = ["!", sys.executable, "-m", "crosshair", "watch", filename]
+        cmd = ["!", "crosshair", "watch", filename]
     else:
         raise NotImplementedError(f"Unhandled command: {command}")
 


### PR DESCRIPTION
There were a couple of problems with crosshair watch command.

First, the screen did not refresh properly, which was fixed in the
version 0.0.13 of crosshair.

Second, invoking crosshair as a module using `sys.executable` caused
crosshair not to verify the file. Once we execute the command just using
`!` in thonny terminal, the problem was resolved.