### PR TITLE
Update version mistakenly released

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setuptools.setup(
     name="thonny-crosshair",
-    version="1.0.0",
+    version="0.0.1",
     author="Marko Ristin",
     author_email="marko@ristin.ch",
     description="Automatically verify Python code using CrossHair in Thonny.",


### PR DESCRIPTION
I mistakenly put the version `1.0.0` instead of `0.0.1`. This patch
reverts the version to the right one.